### PR TITLE
Add config value for ready and unready message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ dependencies {
 }
 
 group = 'com.scainburger.partyreadycheck'
-version = '2.2'
-sourceCompatibility = '1.8'
+version = '2.3'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.release.set(11)
 }

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,6 +1,5 @@
 displayName=Party Ready Check
 author=Scainburger
-support=
 description=Display an alert to check ready status of your party
 tags=tob,theatre,theater,blood,toa,tombs,amascut,party,ready,check
 plugins=com.scainburger.partyreadycheck.PartyReadyCheckPlugin

--- a/src/main/java/com/scainburger/partyreadycheck/PartyReadyCheckConfig.java
+++ b/src/main/java/com/scainburger/partyreadycheck/PartyReadyCheckConfig.java
@@ -18,4 +18,27 @@ public interface PartyReadyCheckConfig extends Config
 					"\"fail.wav\" - Played when ready check times ot <b> "
 	)
 	default boolean useAlternateSounds() { return false; }
+
+
+	@ConfigItem(
+			keyName = "readyMessages",
+			name = "Ready messages",
+			description = "Ready messages to match. Comma,separated,input. Wildcards (*) are accepted.",
+			position = 2
+	)
+	default String readyMessages()
+	{
+		return "r,rr,rrr*,ready,I'm ready,I'm r,Im ready,Im r,pot,send it,readyy,readyyy*,I'm readyy,I'm readyyy*,Im readyy,Im readyyy*,r.*,rr.*,ready.*,I'm ready.*,I'm r.*,Im ready.*,Im r.*,pot.*,send it.*,readyy.*,I'm readyy.*,Im readyy.*,r!*,rr!*,ready!*,I'm ready!*,I'm r!*,Im ready!*,Im r!*,pot!*,send it!*,readyy!*,I'm readyy!*,Im readyy!*";
+	}
+
+	@ConfigItem(
+			keyName = "unreadyMessages",
+			name = "Unready messages",
+			description = "Unready messages to match. Comma,separated,input. Wildcards (*) are accepted.",
+			position = 2
+	)
+	default String unreadyMessages()
+	{
+		return "unr,unrr,unrrr*,unready,un r,un rr,un rrr*,un ready,not ready,I'm not ready,Im not ready,unr.*,unrr.*,unready.*,un r.*,un rr.*,un ready.*,not ready.*,I'm not ready.*,Im not ready.*,unr!*,unrr!*,unready!*,un r!*,un rr!*,un ready!*,not ready!*,I'm not ready!*,Im not ready!*";
+	}
 }


### PR DESCRIPTION
Adds config strings for the ready and unready message.
I noticed a lot of people didn't exactly type r, so this adds config values that support wildcard matching for the messages. Defaults have been set to IMO reasonable values. If there are any potential messages I've missed that should be in the default, please let me know.

Basically closes https://github.com/scainburger/partyreadycheck/issues/5